### PR TITLE
Speed up communication

### DIFF
--- a/orvibo/s20.py
+++ b/orvibo/s20.py
@@ -3,6 +3,7 @@
 import binascii
 import logging
 import socket
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,6 +27,9 @@ PADDING_1 = b'\x20\x20\x20\x20\x20\x20'
 PADDING_2 = b'\x00\x00\x00\x00'
 ON = b'\x01'
 OFF = b'\x00'
+
+# Timeout after which to renew device subscriptions
+SUBSCRIPTION_TIMEOUT = 60
 
 
 def _is_discovery_response(data):
@@ -76,6 +80,8 @@ class S20(object):
             self._socket.setsockopt(socket.SOL_SOCKET, opt, 1)
         self._socket.bind(('', PORT))
         (self._mac, self._mac_reversed) = self._discover_mac()
+
+        self._subscribe()
 
     @property
     def on(self):
@@ -131,10 +137,14 @@ class S20(object):
             + PADDING_1 + self._mac_reversed + PADDING_1
         status = self._udp_transact(cmd, self._subscribe_resp)
         if status is not None:
+            self.last_subscribed = time.time()
             return status == ON
         else:
             raise S20Exception(
                 "No status could be found for {}".format(self.host))
+
+    def _subscription_is_recent(self):
+        return self.last_subscribed > time.time() - SUBSCRIPTION_TIMEOUT
 
     def _control(self, state):
         """ Control device state.
@@ -143,6 +153,11 @@ class S20(object):
 
         :param state: Switch to this state.
         """
+
+        # Renew subscription if necessary
+        if not self._subscription_is_recent():
+            self._subscribe()
+
         cmd = MAGIC + CONTROL + self._mac + PADDING_1 + PADDING_2 + state
         _LOGGER.debug("Sending new state to %s: %s", self.host, ord(state))
         ack_state = self._udp_transact(cmd, self._control_resp, state)
@@ -225,10 +240,8 @@ class S20(object):
 
     def _turn_on(self):
         """ Turn on the device. """
-        if not self._subscribe():
-            self._control(ON)
+        self._control(ON)
 
     def _turn_off(self):
         """ Turn off the device. """
-        if self._subscribe():
-            self._control(OFF)
+        self._control(OFF)

--- a/orvibo/s20.py
+++ b/orvibo/s20.py
@@ -217,11 +217,11 @@ class S20(object):
                     # From the right device?
                     if addr[0] == self.host:
                         retval = handler(data, *args)
+                    # Return as soon as a response is received
+                    if retval:
+                        return retval
                 except socket.timeout:
                     break
-            if retval:
-                break
-        return retval
 
     def _turn_on(self):
         """ Turn on the device. """


### PR DESCRIPTION
Hi,

there was a small bug in `_udp_transact` which caused it to retry until the socket timed out, so every request would take 1 second. I've fixed that one and I also went ahead and changed the subscription logic so that it only resubscribes every 60 seconds instead of for every control request.

I went for 60 seconds because I don't know how long the timeout for subscriptions really is, it could probably be a fair big longer than that.

For me, these changes make communication about twice as fast, but it depends massively on network conditions. The main benefit comes from the `_udp_transact` fix, the subscription only makes everything slightly faster.
