### PR TITLE
Allow subclassed strings to be used

### DIFF
--- a/orvibo/s20.py
+++ b/orvibo/s20.py
@@ -136,7 +136,7 @@ class S20(object):
         if not mac:
             (self._mac, self._mac_reversed) = self._discover_mac()
         else:
-            if type(mac) is str:
+            if isinstance(mac, str):
                 self._mac = binascii.a2b_hex(''.join(mac.split(':')))
             else:
                 self._mac = mac


### PR DESCRIPTION
In Home Assistant, strings coming from YAML configuration are subclassed in a NodeStrClass. The check in this lib is only checking if it's a `str`, not checking if there are subclasses.